### PR TITLE
ライブラリとプロジェクトの紐付けがおかしい件 リカバリ用のジョブ作成

### DIFF
--- a/app/jobs/create_master_library.rb
+++ b/app/jobs/create_master_library.rb
@@ -27,7 +27,6 @@ class CreateMasterLibrary < LibraryRelation
     library_lists.each_with_index do |library, i|
       # 1000件ごとにコミット
       if i % 1000 == 0
-        binding.pry
         MasterLibrary.import results
         results = []
       end

--- a/app/jobs/create_master_library.rb
+++ b/app/jobs/create_master_library.rb
@@ -8,11 +8,40 @@ class CreateMasterLibrary < LibraryRelation
 
   def perform
     # マスタライブラリのクリア
+    MasterLibrary.delete_all
 
-    # 依存ライブラリからライブラリ名一覧を取得し、マスタライブラリに格納する
-    
-    # ライブラリ名からProjectIdを求める(手法はLibraryRelationと同様)
+    # マスタライブラリ作成
+    create_master_libraries
   end
 
   private
+
+  # ライブラリ一覧を取得
+  def library_lists
+    ProjectDependency.where.not(library_name: '').select(:library_name).uniq
+  end
+
+  def create_master_libraries
+    results = []
+    i = 0
+    # 依存ライブラリからライブラリ名一覧を取得し、マスタライブラリに格納する
+    library_lists.each do |library|
+      # 1000件ごとにコミット
+      if (i + 1) % 1000 == 0
+        MasterLibrary.import results
+        results = []
+      end
+
+      # ライブラリ名からProjectIdを求める(手法はLibraryRelationと同様)
+      project_to = find_project_id_based_on_library_name(library.library_name)
+
+      if project_to.present?
+        results << MasterLibrary.new(project_to_id: project_to.id,
+                                     library_name: library.library_name)
+        i = i + 1
+      end
+    end
+
+    MasterLibrary.import results
+  end
 end

--- a/app/jobs/create_master_library.rb
+++ b/app/jobs/create_master_library.rb
@@ -23,11 +23,11 @@ class CreateMasterLibrary < LibraryRelation
 
   def create_master_libraries
     results = []
-    i = 0
     # 依存ライブラリからライブラリ名一覧を取得し、マスタライブラリに格納する
-    library_lists.each do |library|
+    library_lists.each_with_index do |library, i|
       # 1000件ごとにコミット
-      if (i + 1) % 1000 == 0
+      if i % 1000 == 0
+        binding.pry
         MasterLibrary.import results
         results = []
       end
@@ -38,7 +38,8 @@ class CreateMasterLibrary < LibraryRelation
       if project_to.present?
         results << MasterLibrary.new(project_to_id: project_to.id,
                                      library_name: library.library_name)
-        i = i + 1
+      else
+        results << MasterLibrary.new(library_name: library.library_name)
       end
     end
 

--- a/app/jobs/create_master_library.rb
+++ b/app/jobs/create_master_library.rb
@@ -1,0 +1,18 @@
+# マスタライブラリを作成する
+# マスタライブラリは誤ったライブラリの紐付け検出、及び修正のために使用される
+#
+# [使い方]
+#   CreateMasterLibrary.new.perform()
+class CreateMasterLibrary < LibraryRelation
+  queue_as :analyzer
+
+  def perform
+    # マスタライブラリのクリア
+
+    # 依存ライブラリからライブラリ名一覧を取得し、マスタライブラリに格納する
+    
+    # ライブラリ名からProjectIdを求める(手法はLibraryRelationと同様)
+  end
+
+  private
+end

--- a/app/jobs/github_project_recovery_crawler.rb
+++ b/app/jobs/github_project_recovery_crawler.rb
@@ -20,13 +20,13 @@ class GithubProjectRecoveryCrawler < GithubProjectDetailCrawler
     begin
       # 基本情報収集
       results = fetch_project_by_project_id(target.github_item_id)
-      save_projects(target, results)
+      save_projects(target.clone, results)
     rescue => e
       target.attributes = {
         crawl_status: CrawlStatus::ERROR
       }
       target.save!
-      Rails.logger.error('GithubProjectRecoveryCrawler CrawlError:' + e.message)
+      Rails.logger.warn('GithubProjectRecoveryCrawler Warning:' + e.message)
     end
   end
 
@@ -74,7 +74,11 @@ class GithubProjectRecoveryCrawler < GithubProjectDetailCrawler
         language: result["language"],
         default_branch: result["default_branch"]
       }
-      target.save!
+      if result.has_key?('language') && result['language'] != ''
+        target.save!
+      else
+        raise "language is blank"
+      end
     end
   end
 

--- a/app/jobs/library_relation.rb
+++ b/app/jobs/library_relation.rb
@@ -10,8 +10,11 @@ class LibraryRelation < Base
     # ライブラリ紐付け失敗テーブルの初期化
     LibraryRelationError.delete_all
 
-    # 全件入れ替えモードの場合、紐付けを初期化
-    remove_library_relation if mode == 'all'
+    # クリアモードの場合、紐付けを初期化して終了
+    if mode == 'clear'
+      remove_library_relation
+      return
+    end
 
     dependencies = ProjectDependency.where(project_to_id: nil)
     dependencies.find_each do |dependency|

--- a/app/jobs/library_relation.rb
+++ b/app/jobs/library_relation.rb
@@ -16,6 +16,18 @@ class LibraryRelation < Base
       return
     end
 
+    # 紐付けされていない依存ライブラリをプロジェクトIDと紐付ける
+    associate_library_and_project
+
+    # 不完全なプロジェクトを対象に、プロジェクトが完全であるか確認し
+    # in_complete フラグを更新する
+    check_and_update_incomplete_project
+  end
+
+  private
+
+  # 紐付けされていない依存ライブラリをプロジェクトIDと紐付ける
+  def associate_library_and_project
     dependencies = ProjectDependency.where(project_to_id: nil)
     dependencies.find_each do |dependency|
       # rubygems から github_item_id を求め紐付ける
@@ -55,9 +67,11 @@ class LibraryRelation < Base
         dependency.save
       end
     end
+  end
 
-    # 不完全なプロジェクトを対象に、プロジェクトが完全であるか確認し
-    # in_complete フラグを更新する
+  # 不完全なプロジェクトを対象に、プロジェクトが完全であるか確認し
+  # in_complete フラグを更新する
+  def check_and_update_incomplete_project
     projects = Project.incompleted
     projects.find_each do |project|
       next unless project.check_completed?
@@ -70,8 +84,6 @@ class LibraryRelation < Base
       project.save
     end
   end
-
-  private
 
   # 依存ライブラリとプロジェクトIDの関連を削除する
   # プロジェクトは全て不完全とする

--- a/app/jobs/library_relation.rb
+++ b/app/jobs/library_relation.rb
@@ -14,7 +14,7 @@ class LibraryRelation < Base
     remove_library_relation if mode == 'all'
 
     dependencies = ProjectDependency.where(project_to_id: nil)
-    dependencies.each do |dependency|
+    dependencies.find_each do |dependency|
       # rubygems から github_item_id を求め紐付ける
       github_item_id = InputLibrary.get_github_item_id_from_gem_name(
         dependency.library_name

--- a/app/jobs/library_relation.rb
+++ b/app/jobs/library_relation.rb
@@ -24,7 +24,6 @@ class LibraryRelation < Base
     check_and_update_incomplete_project
   end
 
-  protected
   # ライブラリ名でプロジェクトIDを求める
   def find_project_id_based_on_library_name(library_name)
     project_to = nil
@@ -55,6 +54,8 @@ class LibraryRelation < Base
     end
     project_to
   end
+
+  protected
 
   # 不完全なプロジェクトを対象に、プロジェクトが完全であるか確認し
   # in_complete フラグを更新する

--- a/app/jobs/library_relation.rb
+++ b/app/jobs/library_relation.rb
@@ -56,6 +56,22 @@ class LibraryRelation < Base
     project_to
   end
 
+  # 不完全なプロジェクトを対象に、プロジェクトが完全であるか確認し
+  # in_complete フラグを更新する
+  def check_and_update_incomplete_project
+    projects = Project.incompleted
+    projects.find_each do |project|
+      next unless project.check_completed?
+      pt = project.get_project_type
+      project.attributes = {
+        is_incomplete: false,
+        project_type: pt,
+        export_status: ExportStatus::WAITING
+      }
+      project.save
+    end
+  end
+
   private
 
   # 紐付けされていない依存ライブラリをプロジェクトIDと紐付ける
@@ -73,22 +89,6 @@ class LibraryRelation < Base
         dependency.project_to = project_to
         dependency.save
       end
-    end
-  end
-
-  # 不完全なプロジェクトを対象に、プロジェクトが完全であるか確認し
-  # in_complete フラグを更新する
-  def check_and_update_incomplete_project
-    projects = Project.incompleted
-    projects.find_each do |project|
-      next unless project.check_completed?
-      pt = project.get_project_type
-      project.attributes = {
-        is_incomplete: false,
-        project_type: pt,
-        export_status: ExportStatus::WAITING
-      }
-      project.save
     end
   end
 

--- a/app/jobs/library_relation_recovery.rb
+++ b/app/jobs/library_relation_recovery.rb
@@ -30,6 +30,11 @@ class LibraryRelationRecovery < LibraryRelation
         project_to_id: library.project_to_id,
         updated_at: Time.zone.now
       )
+      library.attributes = {
+        status_id: GeneralStatus::DONE.id
+      }
+      library.save!
+      Rails.logger.info("recovery relation #{library.library_name}")
     end
   end
 end

--- a/app/jobs/library_relation_recovery.rb
+++ b/app/jobs/library_relation_recovery.rb
@@ -1,0 +1,35 @@
+# マスタライブラリを元にライブラリ紐付けを再構築する
+#
+# [使い方]
+#   LibraryRelationRecovery.new.perform()
+class LibraryRelationRecovery < LibraryRelation
+  queue_as :analyzer
+
+  def perform(library_project_id: '')
+    # 紐付け再構築対象のマスタライブラリのステータスを未実施にする
+    update_master_library_waiting
+    # 未実施対象に対してライブラリ紐付け行う
+    associate_library_and_project
+  end
+
+  private
+
+  # 紐付け再構築対象のマスタライブラリのステータスを未実施にする
+  def update_master_library_waiting
+    MasterLibrary.update_all(
+      status_id: GeneralStatus::WAITING,
+      updated_at: Time.zone.now
+    )
+  end
+
+  # 未実施対象に対してライブラリ紐付け行う
+  def associate_library_and_project
+    libraries = MasterLibrary.where(status_id: GeneralStatus::WAITING)
+    libraries.find_each do |library|
+      ProjectDependency.where(library_name: library.library_name).update_all(
+        project_to_id: library.project_to_id,
+        updated_at: Time.zone.now
+      )
+    end
+  end
+end

--- a/app/models/general_status.rb
+++ b/app/models/general_status.rb
@@ -1,0 +1,8 @@
+class GeneralStatus < ActiveYaml::Base
+  include ActiveHash::Enum
+
+  set_root_path 'config/division'
+  set_filename 'general_status'
+
+  enum_accessor :type
+end

--- a/app/models/input_project.rb
+++ b/app/models/input_project.rb
@@ -25,6 +25,7 @@
 #  open_issue_count   :integer          default(0), not null
 #  github_score       :string(255)      default(""), not null
 #  language           :string(255)      default(""), not null
+#  default_branch     :string(255)      not null
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/app/models/master_library.rb
+++ b/app/models/master_library.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: master_libraries
+#
+#  id            :integer          not null, primary key
+#  project_to_id :integer
+#  library_name  :string(255)      not null
+#  status_id     :integer          default(10), not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+
+class MasterLibrary < ActiveRecord::Base
+  extend ActiveHash::Associations::ActiveRecordExtension
+  # Relations
+  belongs_to_active_hash :general_status
+  belongs_to :project_to, class_name: 'Project'
+  # Validations
+
+  # Scopes
+
+  # Delegates
+
+  # Class Methods
+
+  # Methods
+end

--- a/app/models/master_library.rb
+++ b/app/models/master_library.rb
@@ -11,7 +11,8 @@
 #
 
 class MasterLibrary < ActiveRecord::Base
-  extend ActiveHash::Associations::ActiveRecordExtension
+  extend ActiveHash::Associations::ActiveRecordExtensions
+
   # Relations
   belongs_to_active_hash :general_status
   belongs_to :project_to, class_name: 'Project'

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -24,9 +24,10 @@
 #  open_issue_count   :integer          default(0), not null
 #  github_score       :string(255)      default(""), not null
 #  language           :string(255)      default(""), not null
+#  default_branch     :string(255)      default("master"), not null
 #  project_type_id    :integer          default(0), not null
 #  export_status_id   :integer          default(0), not null
-#  exported_at        :datetime         not null
+#  exported_at        :datetime
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/config/division/general_status.yml
+++ b/config/division/general_status.yml
@@ -1,0 +1,9 @@
+- id: 0
+  type: waiting
+  name: 待ち
+- id: 2
+  type: done
+  name: 済
+- id: 10
+  type: nontarget
+  name: 対象外

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -172,7 +172,7 @@ ActiveRecord::Schema.define(version: 0) do
   end
 
   add_index "master_libraries", ["library_name"], name: "index_master_libraries_on_library_name", unique: true, using: :btree
-  add_index "master_libraries", ["project_to_id"], name: "index_master_libraries_on_project_to_id", unique: true, using: :btree
+  add_index "master_libraries", ["project_to_id"], name: "index_master_libraries_on_project_to_id", using: :btree
 
   create_table "project_branches", force: :cascade do |t|
     t.integer  "project_id", limit: 4,   null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -273,6 +273,7 @@ ActiveRecord::Schema.define(version: 0) do
 
   add_index "projects", ["full_name"], name: "index_projects_on_full_name", using: :btree
   add_index "projects", ["github_item_id"], name: "index_projects_on_github_item_id", unique: true, using: :btree
+  add_index "projects", ["name"], name: "index_projects_on_name", using: :btree
 
   add_foreign_key "input_branches", "input_projects", name: "input_branches_input_project_id_fk"
   add_foreign_key "input_contents", "input_projects", name: "input_contents_input_project_id_fk"
@@ -284,6 +285,6 @@ ActiveRecord::Schema.define(version: 0) do
   add_foreign_key "project_branches", "projects", name: "project_branches_project_id_fk"
   add_foreign_key "project_readmes", "projects", name: "project_readmes_project_id_fk"
   add_foreign_key "project_tags", "projects", name: "project_tags_project_id_fk"
-  add_foreign_key "project_trees", "projects", name: "project_trees_Project_id_fk"
+  add_foreign_key "project_trees", "projects", column: "Project_id", name: "project_trees_Project_id_fk"
   add_foreign_key "project_weekly_commit_counts", "projects", name: "project_weekly_commit_counts_project_id_fk"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -193,6 +193,7 @@ ActiveRecord::Schema.define(version: 0) do
     t.datetime "updated_at",                  null: false
   end
 
+  add_index "project_dependencies", ["library_name"], name: "index_project_dependencies_on_library_name", using: :btree
   add_index "project_dependencies", ["project_from_id"], name: "index_project_dependencies_on_project_from_id", using: :btree
 
   create_table "project_readmes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -163,6 +163,17 @@ ActiveRecord::Schema.define(version: 0) do
 
   add_index "management_jobs", ["job_id"], name: "management_jobs_job_id", using: :btree
 
+  create_table "master_libraries", force: :cascade do |t|
+    t.integer  "project_to_id", limit: 4
+    t.string   "library_name",  limit: 255,              null: false
+    t.integer  "status_id",     limit: 4,   default: 10, null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+  end
+
+  add_index "master_libraries", ["library_name"], name: "index_master_libraries_on_library_name", unique: true, using: :btree
+  add_index "master_libraries", ["project_to_id"], name: "index_master_libraries_on_project_to_id", unique: true, using: :btree
+
   create_table "project_branches", force: :cascade do |t|
     t.integer  "project_id", limit: 4,   null: false
     t.string   "name",       limit: 255, null: false
@@ -273,6 +284,6 @@ ActiveRecord::Schema.define(version: 0) do
   add_foreign_key "project_branches", "projects", name: "project_branches_project_id_fk"
   add_foreign_key "project_readmes", "projects", name: "project_readmes_project_id_fk"
   add_foreign_key "project_tags", "projects", name: "project_tags_project_id_fk"
-  add_foreign_key "project_trees", "projects", column: "Project_id", name: "project_trees_Project_id_fk"
+  add_foreign_key "project_trees", "projects", name: "project_trees_Project_id_fk"
   add_foreign_key "project_weekly_commit_counts", "projects", name: "project_weekly_commit_counts_project_id_fk"
 end

--- a/db/schema/schema.rb
+++ b/db/schema/schema.rb
@@ -177,6 +177,7 @@ create_table 'project_dependencies', collate: 'utf8_bin', comment: 'プロジェ
   t.varchar :library_name
 
   t.index :project_from_id, unique: false
+  t.index :library_name, unique: false
 
   t.datetime :created_at
   t.datetime :updated_at

--- a/db/schema/schema.rb
+++ b/db/schema/schema.rb
@@ -258,6 +258,21 @@ create_table 'library_relation_errors', collate: 'utf8_bin', comment: 'プロジ
   t.datetime :updated_at
 end
 
+create_table 'master_libraries', collate: 'utf8_bin', comment: 'ライブラリ紐付けチェック用マスタ' do |t|
+  t.int :id, comment: 'Id', primary_key: true, extra: :auto_increment
+
+  t.int :project_to_id, null: true
+  t.varchar :library_name
+  t.int :status_id, default: 10, comment: '反映管理用ステータス'
+
+  t.index :project_to_id, unique: true
+  t.index :library_name, unique: true
+
+  t.datetime :created_at
+  t.datetime :updated_at
+end
+
+
 create_table :delayed_jobs, comment: 'Delayed Job' do |t|
   t.int :id, primary_key: true, extra: 'auto_increment'
   t.int :priority, default: 0, null: false

--- a/db/schema/schema.rb
+++ b/db/schema/schema.rb
@@ -267,7 +267,7 @@ create_table 'master_libraries', collate: 'utf8_bin', comment: 'ライブラリ�
   t.varchar :library_name
   t.int :status_id, default: 10, comment: '反映管理用ステータス'
 
-  t.index :project_to_id, unique: true
+  t.index :project_to_id, unique: false
   t.index :library_name, unique: true
 
   t.datetime :created_at

--- a/db/schema/schema.rb
+++ b/db/schema/schema.rb
@@ -166,6 +166,7 @@ create_table 'projects', collate: 'utf8_bin', comment: 'プロジェクト基本
 
   t.index :github_item_id, unique: true
   t.index :full_name, unique: false
+  t.index :name, unique: false
 end
 
 create_table 'project_dependencies', collate: 'utf8_bin', comment: 'プロジェクト依存関係' do |t|

--- a/spec/jobs/library_relation_spec.rb
+++ b/spec/jobs/library_relation_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe LibraryRelation, type: :model do
-  describe '全件/差分モード確認' do
-    context '全件モードの場合' do
+  describe '全件/クリア/差分モード確認' do
+    context 'クリアモードの場合' do
       before do
         t1 = create(:project,
                     is_incomplete: false)
@@ -10,7 +10,7 @@ RSpec.describe LibraryRelation, type: :model do
                library_name: 'test_not_relation',
                project_from_id: t1.id,
                project_to_id: 1000)
-        LibraryRelation.new.perform(mode: 'all')
+        LibraryRelation.new.perform(mode: 'clear')
       end
 
       it '紐付けテーブルの内容が初期化されること' do


### PR DESCRIPTION
ライブラリのマスター情報を作成するジョブを作成
マスター情報を元に紐付けを再構築するジョブを作成
ライブラリ情報再収集の際のバグ修正
